### PR TITLE
Try to cast flags as Long and if it raises an exception try to cast to a Int in provideFlagsAsLong function

### DIFF
--- a/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
+++ b/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
@@ -238,7 +238,13 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
 
     private fun provideFlags(call: MethodCall): Int = call.argument<Int>(flags) ?: 0
 
-    private fun provideFlagsAsLong(call: MethodCall): Long = call.argument<Long>(flags) ?: 0
+    private fun provideFlagsAsLong(call: MethodCall): Long {
+        return try {
+            call.argument<Long>(flags) ?: 0
+        } catch (e: ClassCastException) {
+            call.argument<Int>(flags)?.toLong() ?: 0
+        }
+    }
 
     @Suppress("UNNECESSARY_SAFE_CALL")
     private fun <F, T> runWithFlags(


### PR DESCRIPTION
## Context
Given the [current possible flags to be used as arguments for the functions from AndroidPackageManager](https://github.com/nubank/android_package_manager/blob/54c91b98207c9002776a4d526527e49d75087e18/lib/src/entities/base/flags.dart#L46-L84), Flutter will always send a `Int` value to the Android platform channel as these flags can all fit in 32-bit integer. However, when the Android platform channel tries to get the flags argument as a `Long` being a `Int` it throws a cast exception.

This PR changes the `provideFlagsAsLong` function to try to get the flags parameter as a `Int` and then casting it to a `Long` when it is not possible to get it directly as a `Long`.